### PR TITLE
Fixed translation of CT always available setting

### DIFF
--- a/platform-ui-bundle/content_type.pl_PL.xlf
+++ b/platform-ui-bundle/content_type.pl_PL.xlf
@@ -49,7 +49,7 @@
       </trans-unit>
       <trans-unit id="d14799b2ac8854ab3f0bb9976258c3db39213d09" resname="content_type.default_availability.value" approved="yes">
         <source>{0} Not available|{1} Available</source>
-        <target xml:lang="pl">{0} Dostępne|{1} Niedostępne</target>
+        <target xml:lang="pl">{0} Niedostępne|{1} Dostępne</target>
         <note>key: content_type.default_availability.value</note>
         <jms:reference-file line="80">Resources/views/ContentType/view_content_type.html.twig</jms:reference-file>
       </trans-unit>


### PR DESCRIPTION
Fixed incorrect translation for the "content_type.default_availability.value" key - the options should be swapped.

It applies to `master` as well, but a location of the file has changed, so needs to be either handled separately or during merge-up.

Visible in the Polish admin interface in Admin -> Content Types -> Content Type view both in v1 and v2